### PR TITLE
Additional masking in Data.convert() to resolve IndexError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of colormaps
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Performing additional masking in Data.convert()
 
 
 1.5 (2018-03-08)

--- a/colormaps/core.py
+++ b/colormaps/core.py
@@ -280,7 +280,10 @@ class GradientColormap(BaseColormap):
             limits = self.limits
 
         data = self.process(data=data, limits=limits)
-        return self.rgba[np.uint64(len(self) * data)]
+
+        # Mask invalid data created by discretisation errors etc.
+        idx = np.abs(np.uint64(len(self) * data)).clip(0, len(self) + 1)
+        return self.rgba[idx]
 
     def get_legend_data(self, limits, steps):
         """We need to interpolate the range, then take a linear range between

--- a/colormaps/core.py
+++ b/colormaps/core.py
@@ -282,7 +282,8 @@ class GradientColormap(BaseColormap):
         data = self.process(data=data, limits=limits)
 
         # Mask invalid data created by discretisation errors etc.
-        idx = np.abs(np.uint64(len(self) * data)).clip(0, len(self) + 1)
+        idx = np.round(len(self) * data).astype(np.uint64)\
+                                        .clip(0, len(self) + 1)
         return self.rgba[idx]
 
     def get_legend_data(self, limits, steps):


### PR DESCRIPTION
A workaround rather than a solution: convert invalid indices to the mask index.