### PR TITLE
Not rounding data index

### DIFF
--- a/colormaps/core.py
+++ b/colormaps/core.py
@@ -282,8 +282,8 @@ class GradientColormap(BaseColormap):
         data = self.process(data=data, limits=limits)
 
         # Mask invalid data created by discretisation errors etc.
-        idx = np.round(len(self) * data).astype(np.uint64)\
-                                        .clip(0, len(self) + 1)
+        idx = (len(self) * data).astype(np.uint64)\
+                                .clip(0, len(self) + 1)
         return self.rgba[idx]
 
     def get_legend_data(self, limits, steps):


### PR DESCRIPTION
np.round() geeft altijd een even getal terug, dat willen we niet. Echter werkt np.rint() ook niet zoals verwacht in de lizard-nxt-test. Dat moet te maken hebben met de manier van hoe de CM geschaald/geinterpoleerd wordt, misschien alleen in het speciaal geval met limits=None, heb ik niet verder nagekeken. Ik zet hem weer naar de oorspronkelijke gedrag, dus naar impliciet 'floor()', en maak een nieuwe ticket aan voor deze issue.