### PR TITLE
[DONE] Mask values outside log's domain.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog of colormaps
 1.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Mask values less or equal to zero for logarithmic colormaps (i.e. make them
+  transparent). A user should still provide no or valid limits. Specifying
+  limits outside the log domain will result in a runtime error.
 
 
 1.8.4 (2020-07-14)

--- a/colormaps/core.py
+++ b/colormaps/core.py
@@ -118,6 +118,11 @@ class BaseColormap(object):
         nan_mask = ~np.isfinite(values)
         mask = nan_mask if mask is None else mask | nan_mask
 
+        # also mask values outside log's domain
+        if self.log:
+            log_mask = values <= 0
+            mask = mask | log_mask
+
         if not np.any(mask):  # np.any(None) returns False
             return self.convert(values, limits)
         rgba = self.masked * np.ones(values.shape + (4,), 'u1')


### PR DESCRIPTION
@arjanverkerk: The log() function is not only applied to `values`, but to `limits` as well. My current fix only addresses `values`. Is it possible for a user to pass invalid `limits` for a request like this?

https://demo.lizard.net/api/v3/wms/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&LAYERS=intern%3Anl%3Aahn3%3Agrp-2018&STYLES=jet_l&FORMAT=image%2Fpng&TRANSPARENT=false&HEIGHT=256&WIDTH=256&TIME=2021-01-19T09%3A10%3A38&SRS=EPSG%3A3857&BBOX=626172.1357121639,6574807.4249777235,782715.1696402048,6731350.458905761

