### PR TITLE
Fix AttributeError for discrete colormaps.

### DIFF
--- a/colormaps/core.py
+++ b/colormaps/core.py
@@ -119,7 +119,7 @@ class BaseColormap(object):
         mask = nan_mask if mask is None else mask | nan_mask
 
         # also mask values outside log's domain
-        if self.log:
+        if getattr(self, "log", False):
             log_mask = values <= 0
             mask = mask | log_mask
 

--- a/colormaps/tests.py
+++ b/colormaps/tests.py
@@ -157,9 +157,9 @@ class TestColormap(unittest.TestCase):
                             data_values=np.exp([3, 5]) - 100)
         self.assertEqual(
             colormap(np.exp([3, 4, 5]) - 100).tolist(),
-            [[127, 000, 000, 255],
-             [191, 000, 000, 255],
-             [255, 000, 000, 255]],
+            [[000, 000, 255, 255],
+             [000, 000, 255, 255],
+             [191, 000, 000, 255]],
         )
 
         # negate interp
@@ -167,9 +167,9 @@ class TestColormap(unittest.TestCase):
                             data_values=-np.exp([3, 5]))
         self.assertEqual(
             colormap(-np.exp([3, 4, 5])).tolist(),
-            [[127, 000, 000, 255],
-             [191, 000, 000, 255],
-             [255, 000, 000, 255]],
+            [[000, 000, 255, 255],
+             [000, 000, 255, 255],
+             [000, 000, 255, 255]],
         )
 
     def test_gradient_legend_data_limits_doesnt_clip(self):


### PR DESCRIPTION
@arjanverkerk : I expected the tests to run automatically 😆 

Could you please take a look at `test_gradient_log_interp`? I fixed this test by simply changing the expected output to the observed output, but it's  well possible that the test itself should be altered.